### PR TITLE
Add configuration option for base directory to glob on

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,11 @@ module.exports = function (grunt) {
             multipleSrc: {
                 src: 'test/examples/*.html',
                 dest: 'test/tmp/multiple-src/'
+            },
+            customBase: {
+                src: 'test/examples-custom-base/content.html',
+                dest: 'test/tmp/custom-base/content.html',
+                base: 'test/examples'
             }
         },
 

--- a/tasks/glob-html.js
+++ b/tasks/glob-html.js
@@ -116,7 +116,11 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask('globhtml', 'Add globbing to your HTML', function () {
         var gruntDir = process.cwd(),
-            dest = this.data.dest;
+            data = this.data,
+            dest = data.dest,
+            baseDir = function(filePath) {
+                return data.base ? data.base : path.dirname(filePath)
+            };
 
         if (!this.filesSrc.length) {
             grunt.log.error('No sources found');
@@ -132,7 +136,7 @@ module.exports = function (grunt) {
             grunt.log.writeln('Processing ' + filePath.cyan);
 
             // Set processing file dir as cwd because script tag source related to the HTML and not to the Grunt file.
-            grunt.file.setBase(path.dirname(filePath));
+            grunt.file.setBase(baseDir(filePath));
             
             // Expand scripts with wildcards.
             processedContent = processFile(content);

--- a/test/examples-custom-base/content.html
+++ b/test/examples-custom-base/content.html
@@ -1,0 +1,1 @@
+../examples/content.html

--- a/test/glob-html.spec.js
+++ b/test/glob-html.spec.js
@@ -9,6 +9,11 @@ describe('glob-html', function(){
             expected = grunt.file.read('test/expected//content.html');
         assert.equal(actual, expected);
     });
+    it('should expand glob sources with custom base drectory', function() {
+        var actual = grunt.file.read('test/tmp/custom-base/content.html'),
+            expected = grunt.file.read('test/expected/content.html');
+        assert.equal(actual, expected);
+    });
     it('should not change file without glob sources', function() {
         var actual = grunt.file.read('test/tmp/multiple-src/empty-content.html'),
             expected = grunt.file.read('test/examples/empty-content.html');


### PR DESCRIPTION
In some cases, the base directory to glob on isn't necessarily the one the HTML file is located in. 
